### PR TITLE
Hardcode chain-id for fork

### DIFF
--- a/scripts/fork-and-cast-spell.sh
+++ b/scripts/fork-and-cast-spell.sh
@@ -19,7 +19,7 @@ else
     extra_params=""
 fi
 
-anvil --fork-url $anvil_fork_url --port ${port} $extra_params &
+anvil --fork-url $anvil_fork_url --port ${port} $extra_params --chain-id 3030 &
 
 sleep 3
 


### PR DESCRIPTION
Using a chain-id that is assigned from base network is insecure and can lead to replay attacks. I propose hardcoding it to a value that aave frontends already use for forked networks -- `3030`. 