### PR TITLE
Do not run spell-caster on master branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,10 @@ jobs:
           forge test -vvv
         id: test
 
+      # submits a PR comment with a spell simulation
       - name: Spell Caster
         uses: marsfoundation/spell-caster@action
+        if: github.event_name == 'pull_request'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           TENDERLY_API_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}


### PR DESCRIPTION
Fixes CI failure on [master](https://github.com/marsfoundation/spark-spells/actions/runs/10167802520/job/28120971382): 
<img width="480" alt="image" src="https://github.com/user-attachments/assets/04e01857-6c4a-4206-851e-456f40b608be">
