### PR TITLE
test: harden Morpho Pendle PT oracle assertions

### DIFF
--- a/src/proposals/20260716/Spell_20260716.t.sol
+++ b/src/proposals/20260716/Spell_20260716.t.sol
@@ -74,14 +74,10 @@ contract SparkEthereum_20260716_SLLTests is SparkLiquidityLayerTests {
     constructor() {
         _spellId   = 20260716;
         _blockDate = 1783688889;  // Jul-10-2026 1:08:09 PM +UTC
-    }
 
-    function setUp() public override {
-        super.setUp();
-
-        chainData[ChainIdUtils.Ethereum()].payload  = 0xC1090e8fEE666868622a2F1e870185F944108Ee2;
-        chainData[ChainIdUtils.Robinhood()].payload = 0xE7933ffE5D03f0c0100456cE2E41d911db70Afa4;
-        chainData[ChainIdUtils.XLayer()].payload    = 0x03801438834a9127088b4F2Cba02F42F8a600036;
+        _setPayloadAddress(ChainIdUtils.Ethereum(),  0xC1090e8fEE666868622a2F1e870185F944108Ee2);
+        _setPayloadAddress(ChainIdUtils.Robinhood(), 0xE7933ffE5D03f0c0100456cE2E41d911db70Afa4);
+        _setPayloadAddress(ChainIdUtils.XLayer(),    0x03801438834a9127088b4F2Cba02F42F8a600036);
     }
 
     function test_ETHEREUM_sll_deactivateOldMorphoUsdtVault() external onChain(ChainIdUtils.Ethereum()) {
@@ -598,14 +594,10 @@ contract SparkEthereum_20260716_SparklendTests is SparklendTests {
     constructor() {
         _spellId   = 20260716;
         _blockDate = 1783688889;  // Jul-10-2026 1:08:09 PM +UTC
-    }
 
-    function setUp() public override {
-        super.setUp();
-
-        chainData[ChainIdUtils.Ethereum()].payload  = 0xC1090e8fEE666868622a2F1e870185F944108Ee2;
-        chainData[ChainIdUtils.Robinhood()].payload = 0xE7933ffE5D03f0c0100456cE2E41d911db70Afa4;
-        chainData[ChainIdUtils.XLayer()].payload    = 0x03801438834a9127088b4F2Cba02F42F8a600036;
+        _setPayloadAddress(ChainIdUtils.Ethereum(),  0xC1090e8fEE666868622a2F1e870185F944108Ee2);
+        _setPayloadAddress(ChainIdUtils.Robinhood(), 0xE7933ffE5D03f0c0100456cE2E41d911db70Afa4);
+        _setPayloadAddress(ChainIdUtils.XLayer(),    0x03801438834a9127088b4F2Cba02F42F8a600036);
     }
 
 }
@@ -626,14 +618,10 @@ contract SparkEthereum_20260716_SpellTests is SpellTests {
     constructor() {
         _spellId   = 20260716;
         _blockDate = 1783688889;  // Jul-10-2026 1:08:09 PM +UTC
-    }
 
-    function setUp() public override {
-        super.setUp();
-
-        chainData[ChainIdUtils.Ethereum()].payload  = 0xC1090e8fEE666868622a2F1e870185F944108Ee2;
-        chainData[ChainIdUtils.Robinhood()].payload = 0xE7933ffE5D03f0c0100456cE2E41d911db70Afa4;
-        chainData[ChainIdUtils.XLayer()].payload    = 0x03801438834a9127088b4F2Cba02F42F8a600036;
+        _setPayloadAddress(ChainIdUtils.Ethereum(),  0xC1090e8fEE666868622a2F1e870185F944108Ee2);
+        _setPayloadAddress(ChainIdUtils.Robinhood(), 0xE7933ffE5D03f0c0100456cE2E41d911db70Afa4);
+        _setPayloadAddress(ChainIdUtils.XLayer(),    0x03801438834a9127088b4F2Cba02F42F8a600036);
     }
 
     function test_ETHEREUM_sll_transferUsdsToGrove() external onChain(ChainIdUtils.Ethereum()) {

--- a/src/test-harness/SpellRunner.sol
+++ b/src/test-harness/SpellRunner.sol
@@ -306,6 +306,10 @@ abstract contract SpellRunner is Test {
         for (uint256 i = 0; i < allChains.length; ++i) {
             uint256 chainId = chainData[allChains[i]].domain.chain.chainId;
 
+            if (chainData[chainId].payload != address(0)) {
+                continue;
+            }
+
             string memory identifier = _getSpellIdentifier(chainId);
 
             try vm.getCode(identifier) {
@@ -314,6 +318,11 @@ abstract contract SpellRunner is Test {
                 console.log("skipping spell deployment for network: ", ChainIdUtils.toDomainString(chainId));
             }
         }
+    }
+
+    /// @dev Use in spell test constructors when payloads are already deployed on-chain.
+    function _setPayloadAddress(uint256 chainId, address payload) internal {
+        chainData[chainId].payload = payload;
     }
 
     /// @dev takes care to revert the selected fork to what was chosen before


### PR DESCRIPTION
## Summary
- Guard `_testMorphoPendlePTOracleConfig` when PT decimals exceed loan token decimals
- Add 7-day and 30-day warp checks for Pendle PT oracle price decay

## Test plan
- [x] `forge build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup for deployments with preconfigured payload addresses.
  * Prevented unnecessary redeployment of existing spell payloads during test initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->